### PR TITLE
add endpoint parameter for sovereign cloud

### DIFF
--- a/fluent-plugin-azure-loganalytics.gemspec
+++ b/fluent-plugin-azure-loganalytics.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_dependency "rest-client"
-  gem.add_dependency "azure-loganalytics-datacollector-api", [">= 0.1.2"]
+  gem.add_dependency "azure-loganalytics-datacollector-api", [">= 0.1.5"]
   gem.add_development_dependency "bundler", "~> 1.11"
   gem.add_development_dependency "rake", "~> 10.0"
   gem.add_development_dependency "test-unit"

--- a/lib/fluent/plugin/out_azure-loganalytics.rb
+++ b/lib/fluent/plugin/out_azure-loganalytics.rb
@@ -16,6 +16,8 @@ module Fluent::Plugin
                  :desc => "Your Operations Management Suite workspace ID"
     config_param :shared_key, :string, :secret => true,
                  :desc => "The primary or the secondary Connected Sources client authentication key"
+    config_param :endpoint, :string, :default =>'ods.opinsights.azure.com',
+                 :desc => "The service endpoint"
     config_param :log_type, :string,
                  :desc => "The name of the event type that is being submitted to Log Analytics. log_type only alpha characters"
     config_param :time_generated_field, :string, :default => '',
@@ -59,7 +61,7 @@ module Fluent::Plugin
     def start
       super
       # start
-      @client=Azure::Loganalytics::Datacollectorapi::Client::new(@customer_id,@shared_key)
+      @client=Azure::Loganalytics::Datacollectorapi::Client::new(@customer_id,@shared_key,@endpoint)
     end
 
     def shutdown


### PR DESCRIPTION
add endpoint parameter and upgrade azure-loganalytics-datacollector-api version to 0.1.5 to support sovereign cloud

I already pulled request for azure-loganalytics-datacollector-api as the base dependency.  