### PR TITLE
Fix incorrect statement split, use more relaxed JSON encoder

### DIFF
--- a/fluent-plugin-azure-loganalytics.gemspec
+++ b/fluent-plugin-azure-loganalytics.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "fluentd", [">= 0.14.15", "< 2"]
   gem.add_dependency "rest-client"
+  gem.add_dependency "yajl-ruby"
   gem.add_dependency "azure-loganalytics-datacollector-api", [">= 0.1.5"]
   gem.add_development_dependency "bundler", "~> 1.11"
   gem.add_development_dependency "rake", "~> 10.0"

--- a/lib/fluent/plugin/out_azure-loganalytics.rb
+++ b/lib/fluent/plugin/out_azure-loganalytics.rb
@@ -95,12 +95,12 @@ module Fluent::Plugin
       begin
         res = @client.post_data(@log_type, records, @time_generated_field)
         if not Azure::Loganalytics::Datacollectorapi::Client.is_success(res)
-          log.fatal "DataCollector API request failure: error code: "
-                  + "#{res.code}, data=>" + records.to_json
+          log.fatal "DataCollector API request failure: error code: " +
+                  "#{res.code}, data=>" + Yajl.dump(records)
         end
       rescue Exception => ex
-        log.fatal "Exception occured in posting to DataCollector API: "
-                  + "'#{ex}', data=>" + records.to_json
+        log.fatal "Exception occured in posting to DataCollector API: " +
+                  "'#{ex}', data=>" + Yajl.dump(records)
       end
     end
   end


### PR DESCRIPTION
`log.fatal` statement was split incorrectly into lines, so that part of
the message is actually not logged.

Use 'yajl' instead of default JSON encoder, due to the following problem
observed:

```
2019-07-29 19:47:09 +0000 [warn]: #0 failed to flush the buffer. retry_time=0 next_retry_seconds=2019-07-29 19:47:10 +0000 chunk="58e09d319b82a042ddc2fef0edb883b1" error_class=Encoding::UndefinedConversionError error="\"\\xE2\" from ASCII-8BIT to UTF-8"
  2019-07-29 19:47:09 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-azure-loganalytics-0.3.1/lib/fluent/plugin/out_azure-loganalytics.rb:101:in `encode'
  2019-07-29 19:47:09 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-azure-loganalytics-0.3.1/lib/fluent/plugin/out_azure-loganalytics.rb:101:in `to_json'
  2019-07-29 19:47:09 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-azure-loganalytics-0.3.1/lib/fluent/plugin/out_azure-loganalytics.rb:101:in `rescue in write'
  2019-07-29 19:47:09 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluent-plugin-azure-loganalytics-0.3.1/lib/fluent/plugin/out_azure-loganalytics.rb:93:in `write'
  2019-07-29 19:47:09 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.4.2/lib/fluent/plugin/output.rb:1125:in `try_flush'
  2019-07-29 19:47:09 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.4.2/lib/fluent/plugin/output.rb:1425:in `flush_thread_run'
  2019-07-29 19:47:09 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.4.2/lib/fluent/plugin/output.rb:454:in `block (2 levels) in start'
  2019-07-29 19:47:09 +0000 [warn]: #0 /usr/lib/ruby/gems/2.5.0/gems/fluentd-1.4.2/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
```